### PR TITLE
Add canMakePayment intervention to the PaymentRequest prototype for Microsoft Edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ To make use of the shim, simply add this script tag to your page *before* making
 
 - Android WebView exposed the Payment Request API [by mistake](https://bugs.chromium.org/p/chromium/issues/detail?id=667069). The shim sets the API to null when this occurs.
 - Chrome for iOS exposed the Payment Request API [by mistake](https://bugs.chromium.org/p/chromium/issues/detail?id=734586). The shim sets the API to null when this occurs.
+- Add canMakePayment polyfill to the PaymentRequest prototype on Microsoft Edge. The polyfill returns true if the logged in user has a card on file that is supported by the platform; otherwise, returns false.
+  Note that the cards on file are not mediated against the supported networks listed in the PaymentRequest methodData.
 
 ## License
 

--- a/src/interventions/edge-canMakePayment.js
+++ b/src/interventions/edge-canMakePayment.js
@@ -107,6 +107,14 @@ function canMakePayment() {
  * @return {Promise}
  */
 function canMakePaymentPolyfill() {
+    /* eslint-disable no-console */
+    console.log('canMakePayment() is polyfilled. The polyfill returns true ' +
+        'if the logged in user has a card on file that is supported by the ' +
+        'platform; otherwise, returns false.  The cards on file are ' +
+        'currently not mediated against the supported networks listed in the ' +
+        'PaymentRequest methodData.');
+    /* eslint-enable no-console */
+
     return ready()
         .then(() => {
             return Promise.race([canMakePayment(), timeout(timeoutInMs)]);

--- a/src/interventions/edge-canMakePayment.js
+++ b/src/interventions/edge-canMakePayment.js
@@ -1,0 +1,79 @@
+/**
+Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * README
+ *
+ * This intervention adds canMakePayment to the PaymentRequest prototype on Microsoft Edge 40.15063.0.0.
+ * The canMakePayment polyfill returns true if the logged in user has a card on file that is supported by Microsoft wallet; otherwise, returns false. 
+ * Note: The payment instruments the user has on file are not mediated against the supported networks listed in the PaymentRequest methodData since this field is internal. 
+ */
+
+'use strict';
+
+const baseUrl = 'https://wallet.microsoft.com';
+const canMakePaymentUrl = `${baseUrl}/preview/canMakePayment`;
+
+const canMakePaymentPolyfill = () => {
+    return new Promise((resolve, reject) => {
+        const body = document.getElementsByTagName('body')[0];
+        const iframe = document.createElement('iframe');
+        iframe.id = 'edge-canMakePayment-iframe';
+        iframe.src = canMakePaymentUrl;
+        iframe.style.display = 'none';
+        iframe.style.width = '1px';
+        iframe.style.height = '1px';
+
+        const messageHandler = (event) => {
+            if (event.origin !== baseUrl) {
+                return;
+            }
+
+            window.removeEventListener('message', messageHandler);
+            body.removeChild(iframe);
+            const result = event.data.canMakePayment;
+            resolve(result);
+        };
+
+        const errorHandler = () => {
+            // Failed to load the canMakePayment iframe.
+            window.removeEventListener('message', messageHandler);
+            body.removeChild(iframe);
+            resolve(false);
+        };
+
+        window.addEventListener('message', messageHandler);
+        iframe.onerror = errorHandler;
+        body.appendChild(iframe);
+    });
+};
+
+module.exports = (window, navigator) => {
+    if (!window.PaymentRequest) {
+        return;
+    }
+
+    const userAgent = navigator.userAgent;
+    if (userAgent.indexOf('Edge/') < 0) {
+        return;
+    }
+
+    if ('canMakePayment' in window.PaymentRequest.prototype) {
+        return;
+    }
+
+    window.PaymentRequest.prototype.canMakePayment = canMakePaymentPolyfill;
+};

--- a/src/interventions/edge-canMakePayment.js
+++ b/src/interventions/edge-canMakePayment.js
@@ -17,9 +17,13 @@ limitations under the License.
 /**
  * README
  *
- * This intervention adds canMakePayment to the PaymentRequest prototype on Microsoft Edge 40.15063.0.0.
- * The canMakePayment polyfill returns true if the logged in user has a card on file that is supported by Microsoft wallet; otherwise, returns false. 
- * Note: The payment instruments the user has on file are not mediated against the supported networks listed in the PaymentRequest methodData since this field is internal. 
+ * This intervention adds canMakePayment to the PaymentRequest prototype on
+ * Microsoft Edge 40.15063.0.0.
+ * The canMakePayment polyfill returns true if the logged in user has a card on
+ * file that is supported by Microsoft wallet; otherwise, returns false.
+ * Note: The payment instruments the user has on file are not mediated against
+ * the supported networks listed in the PaymentRequest methodData since this
+ * field is internal.
  */
 
 'use strict';
@@ -28,8 +32,11 @@ const baseUrl = 'https://wallet.microsoft.com';
 const canMakePaymentUrl = `${baseUrl}/preview/canMakePayment`;
 const timeoutInMs = 30000;
 
+/**
+ * Ensure the document is ready.
+ * @return {Promise}
+ */
 function ready() {
-    // Ensure the document is ready.
     return new Promise((resolve, reject) => {
         if (document.readyState === 'loading') {
             document.addEventListener('DOMContentLoaded', resolve);
@@ -39,8 +46,12 @@ function ready() {
     });
 }
 
+/**
+ * Create a promise that rejects in <ms> milliseconds.
+ * @param {number}  ms - timeout in milliseconds.
+ * @return {Promise}
+ */
 function timeout(ms) {
-    // Create a promise that rejects in <ms> milliseconds.
     return new Promise((resolve, reject) => {
         let id = setTimeout(() => {
             clearTimeout(id);
@@ -49,6 +60,11 @@ function timeout(ms) {
     });
 }
 
+/**
+ * The canMakePayment function returns true if the logged in user has a card on
+ * file that is supported by Microsoft wallet; otherwise, returns false.
+ * @return {Promise}
+ */
 function canMakePayment() {
     return new Promise((resolve, reject) => {
         const body = document.body;
@@ -60,7 +76,8 @@ function canMakePayment() {
         iframe.style.height = '1px';
 
         const messageHandler = (event) => {
-            if (event.origin !== baseUrl || event.data.canMakePayment === undefined) {
+            if (event.origin !== baseUrl ||
+                event.data.canMakePayment === undefined) {
                 return;
             }
 
@@ -83,6 +100,12 @@ function canMakePayment() {
     });
 }
 
+/**
+ * The canMakePayment polyfill returns true if the logged in user has a card on
+ * file that is supported by Microsoft wallet; otherwise, returns false.
+ * Rejects if the canMakePayment promise is not resolved in the alloted timeout.
+ * @return {Promise}
+ */
 function canMakePaymentPolyfill() {
     return ready()
         .then(() => {

--- a/src/shim.js
+++ b/src/shim.js
@@ -15,5 +15,7 @@ limitations under the License.
 */
 
 const androidWebview = require('./interventions/android-webview-53-54');
+const edgeCanMakePaymentIntervention = require('./interventions/edge-canMakePayment');
 
 androidWebview(window, navigator);
+edgeCanMakePaymentIntervention(window, navigator);

--- a/src/shim.js
+++ b/src/shim.js
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 const androidWebview = require('./interventions/android-webview-53-54');
-const edgeCanMakePaymentIntervention = require('./interventions/edge-canMakePayment');
+const edgeCanMakePayment = require('./interventions/edge-canMakePayment');
 
 androidWebview(window, navigator);
-edgeCanMakePaymentIntervention(window, navigator);
+edgeCanMakePayment(window, navigator);

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -6,5 +6,6 @@
   "rules": {
     "max-len": 0,
     "no-console": 0,
+    "require-jsdoc": 0,
   }
 }

--- a/test/edge-canMakePayment-tests.js
+++ b/test/edge-canMakePayment-tests.js
@@ -36,7 +36,7 @@ describe('Edge canMakePayment Shim', () => {
 
   it('should not override canMakePayment method', () => {
     let window = {
-      PaymentRequest: InjectedNewPaymentRequest
+      PaymentRequest: InjectedNewPaymentRequest,
     };
     let navigator = {
       userAgent: MATCHING_USER_AGENT,
@@ -52,10 +52,10 @@ describe('Edge canMakePayment Shim', () => {
 
   it(`should not add canMakePayment method when user agent is "${NON_MATCHING_USER_AGENT}"`, () => {
     let window = {
-      PaymentRequest: InjectedPaymentRequest
+      PaymentRequest: InjectedPaymentRequest,
     };
     let navigator = {
-      userAgent: NON_MATCHING_USER_AGENT
+      userAgent: NON_MATCHING_USER_AGENT,
     };
 
     edgeCanMakePaymentIntervention(window, navigator);
@@ -65,7 +65,7 @@ describe('Edge canMakePayment Shim', () => {
 
   it(`should add missing canMakePayment method when user agent is "${MATCHING_USER_AGENT}"`, () => {
     let window = {
-      PaymentRequest: InjectedPaymentRequest
+      PaymentRequest: InjectedPaymentRequest,
     };
     let navigator = {
       userAgent: MATCHING_USER_AGENT,

--- a/test/edge-canMakePayment-tests.js
+++ b/test/edge-canMakePayment-tests.js
@@ -1,0 +1,78 @@
+/**
+Copyright 2016 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+'use strict';
+
+const edgeCanMakePaymentIntervention = require('../src/interventions/edge-canMakePayment.js');
+
+require('chai').should();
+
+class InjectedPaymentRequest {}
+
+const injecteCanMakePaymentResult = 'injectedResult';
+
+class InjectedNewPaymentRequest {
+  canMakePayment() {
+    return injecteCanMakePaymentResult;
+  }
+}
+
+describe('Edge canMakePayment Shim', () => {
+  const NON_MATCHING_USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.21 Safari/537.36';
+  const MATCHING_USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.15063';
+
+  it('should not override canMakePayment method', () => {
+    let window = {
+      PaymentRequest: InjectedNewPaymentRequest
+    };
+    let navigator = {
+      userAgent: MATCHING_USER_AGENT,
+    };
+
+    edgeCanMakePaymentIntervention(window, navigator);
+
+    ('canMakePayment' in window.PaymentRequest.prototype).should.equal(true);
+
+    const paymentRequest = new window.PaymentRequest();
+    paymentRequest.canMakePayment().should.equal(injecteCanMakePaymentResult);
+  });
+
+  it(`should not add canMakePayment method when user agent is "${NON_MATCHING_USER_AGENT}"`, () => {
+    let window = {
+      PaymentRequest: InjectedPaymentRequest
+    };
+    let navigator = {
+      userAgent: NON_MATCHING_USER_AGENT
+    };
+
+    edgeCanMakePaymentIntervention(window, navigator);
+
+    ('canMakePayment' in window.PaymentRequest.prototype).should.equal(false);
+  });
+
+  it(`should add missing canMakePayment method when user agent is "${MATCHING_USER_AGENT}"`, () => {
+    let window = {
+      PaymentRequest: InjectedPaymentRequest
+    };
+    let navigator = {
+      userAgent: MATCHING_USER_AGENT,
+    };
+
+    edgeCanMakePaymentIntervention(window, navigator);
+
+    ('canMakePayment' in window.PaymentRequest.prototype).should.equal(true);
+  });
+});


### PR DESCRIPTION
We’d like to add a canMakePayment intervention for Microsoft Edge.
The canMakePayment polyfill returns true if the logged in user has a card on file that is supported by Microsoft wallet; otherwise, returns false. 
A native implementation of the canMakePayment will be added to Edge later this year. 
Happy to have the opportunity to collaborate on the Payment Request API!

Thanks!