### PR TITLE
Converts all the numbers to strings in PaymentDetails

### DIFF
--- a/src/interventions/chrome-ios-62-63.js
+++ b/src/interventions/chrome-ios-62-63.js
@@ -1,0 +1,147 @@
+/**
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * README
+ *
+ * This intervention handles the scenario where Chrome cannot handle a number
+ * passed as the PaymentCurrencyAmount.value for iOS.
+ *
+ * https://bugs.chromium.org/p/chromium/issues/detail?id=785429
+ *
+ * FIX
+ *
+ * This code checks the UserAgent to see if the current environment is Chrome
+ * for iOS version 62 or 63 and if it is converts the numbers in all
+ * PaymentCurrencyAmount.value instances to strings before passing the objects
+ * to the browser.
+ */
+
+/**
+ * Converts a PaymentCurrencyAmount.value from number to string, if any.
+ * @param {(window.PaymentCurrencyAmount|undefined)} amount
+ */
+function convertPaymentCurrencyAmount(amount) {
+  if (!amount) {
+    return;
+  }
+
+  // Convert the value to String if it isn't one already.
+  amount.value = String(amount.value);
+}
+
+/**
+ * Converts PaymentCurrencyAmount.value instances from number to string inside
+ * instances of PaymentItem, if any.
+ * @param {(Array<!window.PaymentItem>|undefined)} displayItems
+ */
+function convertDisplayItems(displayItems) {
+  if (!displayItems || !(displayItems instanceof Array)) {
+    return;
+  }
+
+  for (let i = 0; i < displayItems.length; i++) {
+    convertPaymentCurrencyAmount(displayItems[i].amount);
+  }
+}
+
+/**
+ * Converts PaymentCurrencyAmount.value instances from number to string inside
+ * instances of PaymentShippingOption, if any.
+ * @param {(Array<!window.PaymentShippingOption>|undefined)} shippingOptions
+ */
+function convertShippingOptions(shippingOptions) {
+  if (!shippingOptions || !(shippingOptions instanceof Array)) {
+    return;
+  }
+
+  for (let i = 0; i < shippingOptions.length; i++) {
+    convertPaymentCurrencyAmount(shippingOptions[i].amount);
+  }
+}
+
+/**
+ * Converts PaymentCurrencyAmount.value instances from number to string inside
+ * an instance of PaymentDetails, if any.
+ * @param {(window.PaymentDetails|undefined)} details
+ */
+function convertPaymentDetails(details) {
+  if (!details) {
+    return;
+  }
+
+  if (details.total) {
+    convertPaymentCurrencyAmount(details.total.amount);
+  }
+  convertDisplayItems(details.displayItems);
+  convertShippingOptions(details.shippingOptions);
+  convertPaymentDetailsModifiers(details.modifiers);
+}
+
+/**
+ * Converts PaymentCurrencyAmount.value instances from number to string inside
+ * instances of PaymentDetailsModifier, if any.
+ * @param {(Array<!window.PaymentDetailsModifier>|undefined)} modifiers
+ */
+function convertPaymentDetailsModifiers(modifiers) {
+  if (!modifiers || !(modifiers instanceof Array)) {
+    return;
+  }
+
+  for (let i = 0; i < modifiers.length; i++) {
+    if (modifiers[i].total) {
+      convertPaymentCurrencyAmount(modifiers[i].total.amount);
+    }
+    convertDisplayItems(modifiers[i].additionalDisplayItems);
+  }
+}
+
+module.exports = (window, navigator) => {
+  if (!window.PaymentRequest) {
+    return;
+  }
+
+  if (/CriOS\/(62|63)/.test(navigator.userAgent)) {
+    let originalPaymentRequest = window.PaymentRequest;
+
+    window.PaymentRequest = function(methodData, details, optOptions) {
+      convertPaymentDetails(details);
+      originalPaymentRequest.call(this, methodData, details, optOptions);
+    };
+
+    window.PaymentRequest.prototype.__proto__ =
+        originalPaymentRequest.prototype;
+
+    /* eslint-disable no-undef */
+    let originalUpdateWith = __gCrWeb['paymentRequestManager'].updateWith;
+
+    __gCrWeb['paymentRequestManager'].updateWith = function(detailsOrPromise) {
+      // if |detailsOrPromise| is not an instance of a Promise, wrap it in a
+      // Promise that fulfills with |detailsOrPromise|.
+      if (!detailsOrPromise || !(detailsOrPromise.then instanceof Function) ||
+          !(detailsOrPromise.catch instanceof Function)) {
+        detailsOrPromise = Promise.resolve(detailsOrPromise);
+      }
+
+      let self = this;
+      detailsOrPromise
+          .then(function(paymentDetails) {
+            convertPaymentDetails(paymentDetails);
+            originalUpdateWith.call(self, paymentDetails);
+          });
+    };
+  }
+};

--- a/src/interventions/chrome-ios-62-63.js
+++ b/src/interventions/chrome-ios-62-63.js
@@ -61,24 +61,6 @@ function convertDisplayItemsOrShippingOptions(items) {
 
 /**
  * Converts PaymentCurrencyAmount.value instances from number to string inside
- * an instance of PaymentDetails, if any.
- * @param {(window.PaymentDetails|undefined)} details
- */
-function convertPaymentDetails(details) {
-  if (!details) {
-    return;
-  }
-
-  if (details.total) {
-    convertPaymentCurrencyAmount(details.total.amount);
-  }
-  convertDisplayItemsOrShippingOptions(details.displayItems);
-  convertDisplayItemsOrShippingOptions(details.shippingOptions);
-  convertPaymentDetailsModifiers(details.modifiers);
-}
-
-/**
- * Converts PaymentCurrencyAmount.value instances from number to string inside
  * instances of PaymentDetailsModifier, if any.
  * @param {(Array<!window.PaymentDetailsModifier>|undefined)} modifiers
  */
@@ -93,6 +75,24 @@ function convertPaymentDetailsModifiers(modifiers) {
     }
     convertDisplayItemsOrShippingOptions(modifiers[i].additionalDisplayItems);
   }
+}
+
+/**
+ * Converts PaymentCurrencyAmount.value instances from number to string inside
+ * an instance of PaymentDetails, if any.
+ * @param {(window.PaymentDetails|undefined)} details
+ */
+function convertPaymentDetails(details) {
+  if (!details) {
+    return;
+  }
+
+  if (details.total) {
+    convertPaymentCurrencyAmount(details.total.amount);
+  }
+  convertDisplayItemsOrShippingOptions(details.displayItems);
+  convertDisplayItemsOrShippingOptions(details.shippingOptions);
+  convertPaymentDetailsModifiers(details.modifiers);
 }
 
 module.exports = (window, navigator) => {

--- a/src/interventions/chrome-ios-62-63.js
+++ b/src/interventions/chrome-ios-62-63.js
@@ -45,31 +45,17 @@ function convertPaymentCurrencyAmount(amount) {
 
 /**
  * Converts PaymentCurrencyAmount.value instances from number to string inside
- * instances of PaymentItem, if any.
- * @param {(Array<!window.PaymentItem>|undefined)} displayItems
+ * instances of PaymentShippingOption or PaymentItem, if any.
+ * @param {(Array<!window.PaymentShippingOption|!window.PaymentItem>|undefined)}
+ *     items
  */
-function convertDisplayItems(displayItems) {
-  if (!displayItems || !(displayItems instanceof Array)) {
+function convertDisplayItemsOrShippingOptions(items) {
+  if (!items || !(items instanceof Array)) {
     return;
   }
 
-  for (let i = 0; i < displayItems.length; i++) {
-    convertPaymentCurrencyAmount(displayItems[i].amount);
-  }
-}
-
-/**
- * Converts PaymentCurrencyAmount.value instances from number to string inside
- * instances of PaymentShippingOption, if any.
- * @param {(Array<!window.PaymentShippingOption>|undefined)} shippingOptions
- */
-function convertShippingOptions(shippingOptions) {
-  if (!shippingOptions || !(shippingOptions instanceof Array)) {
-    return;
-  }
-
-  for (let i = 0; i < shippingOptions.length; i++) {
-    convertPaymentCurrencyAmount(shippingOptions[i].amount);
+  for (let i = 0; i < items.length; i++) {
+    convertPaymentCurrencyAmount(items[i].amount);
   }
 }
 
@@ -86,8 +72,8 @@ function convertPaymentDetails(details) {
   if (details.total) {
     convertPaymentCurrencyAmount(details.total.amount);
   }
-  convertDisplayItems(details.displayItems);
-  convertShippingOptions(details.shippingOptions);
+  convertDisplayItemsOrShippingOptions(details.displayItems);
+  convertDisplayItemsOrShippingOptions(details.shippingOptions);
   convertPaymentDetailsModifiers(details.modifiers);
 }
 
@@ -105,7 +91,7 @@ function convertPaymentDetailsModifiers(modifiers) {
     if (modifiers[i].total) {
       convertPaymentCurrencyAmount(modifiers[i].total.amount);
     }
-    convertDisplayItems(modifiers[i].additionalDisplayItems);
+    convertDisplayItemsOrShippingOptions(modifiers[i].additionalDisplayItems);
   }
 }
 

--- a/src/shim.js
+++ b/src/shim.js
@@ -15,9 +15,11 @@ limitations under the License.
 */
 
 const androidWebview = require('./interventions/android-webview-53-54');
-const chromeIos = require('./interventions/chrome-ios-59');
+const chromeIos59 = require('./interventions/chrome-ios-59');
+const chromeIos6263 = require('./interventions/chrome-ios-62-63');
 const edgeCanMakePayment = require('./interventions/edge-canMakePayment');
 
 androidWebview(window, navigator);
-chromeIos(window, navigator);
+chromeIos59(window, navigator);
+chromeIos6263(window, navigator);
 edgeCanMakePayment(window, navigator);

--- a/test/demo/ios-62-63/index.html
+++ b/test/demo/ios-62-63/index.html
@@ -80,8 +80,8 @@
   };
 
   // Clone details to use as the updateWith() method argument.
-  let addressUpdateDetails = JSON.parse(JSON.stringify(details));
-  let optionUpdateDetails = JSON.parse(JSON.stringify(details));
+  var addressUpdateDetails = JSON.parse(JSON.stringify(details));
+  var optionUpdateDetails = JSON.parse(JSON.stringify(details));
 
   var request = new PaymentRequest(supportedInstruments, details, options);
 

--- a/test/demo/ios-62-63/index.html
+++ b/test/demo/ios-62-63/index.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/build/payment-shim.js"></script>
+<script type="text/javascript">
+  var supportedInstruments = [{
+        supportedMethods: [
+            'basic-card',
+        ]
+    }];
+
+  var details = {
+      total: {
+          label: 'Total',
+          amount: {
+              currency: 'USD',
+              value: 55
+          }
+      },
+      displayItems: [{
+          label: 'Total amount',
+          amount: {
+              currency: 'USD',
+              value: 65
+          }
+      }, {
+          label: 'Discount',
+          amount: {
+              currency: 'USD',
+              value: -10
+          }
+      }, {
+          label: 'Shipping',
+          amount: {
+              currency: 'USD',
+              value: 0
+          }
+      }],
+      shippingOptions: [{
+          id: 'standard',
+          label: 'Standard shipping',
+          amount: {
+              currency: 'USD',
+              value: 0.00
+          },
+          selected: true
+      }, {
+          id: 'expedited',
+          label: 'Expedited shipping',
+          amount: {
+              currency: 'USD',
+              value: 0.9999
+          },
+          selected: false
+      }],
+      modifiers: [{
+          supportedMethods: ['basic-card'],
+          total: {
+              label: 'Total',
+              amount: {
+                  currency: 'USD',
+                  value: 45.00
+              }
+          },
+          additionalDisplayItems: [{
+              label: 'Visa discount',
+              amount: {
+                  currency: 'USD',
+                  value: -10.00
+              }
+          }],
+          data: {
+              supportedNetworks: ['visa'],
+          }
+      }]
+  };
+
+  var options = {
+      requestShipping: true
+  };
+
+  // Clone details to use as the updateWith() method argument.
+  let addressUpdateDetails = JSON.parse(JSON.stringify(details));
+  let optionUpdateDetails = JSON.parse(JSON.stringify(details));
+
+  var request = new PaymentRequest(supportedInstruments, details, options);
+
+  request.addEventListener('shippingaddresschange', function(e) {
+      e.updateWith(new Promise(function(resolve) {
+          resolve(addressUpdateDetails);
+      }));
+  });
+
+  request.addEventListener('shippingoptionchange', function(e) {
+      e.updateWith(new Promise(function(resolve) {
+          resolve(optionUpdateDetails);
+      }));
+  });
+
+  request.show()
+      .then(function(response) {
+          response.complete('success');
+      })
+      .catch(function(err) {
+          console.error(err);
+      });
+</script>
+</head>
+<body>
+  <p>
+    Tests whether numbers are successfully converted to strings in PaymentDetails.
+  </p>
+  <p>
+    Payment Request UI must show. User should be able to change the shipping
+    address and shipping option (selected shipping option won't really change).
+  </p>
+</body>


### PR DESCRIPTION
Numbers being passed as currency amount values can break PaymentRequest on
iOS since numbers don't automatically get converted to strings and the code
expects string in M62 and M63 releases. This intervation prevents that from
happening by converting all the numbers to strings in PaymentDetails