### PR TITLE
`undefined` instead of `null`

### DIFF
--- a/src/interventions/chrome-incognito.js
+++ b/src/interventions/chrome-incognito.js
@@ -32,8 +32,8 @@ limitations under the License.
  * Disables Payment Request.
  */
 function disablePaymentRequest() {
-    window.PaymentRequest = null;
-    window.PaymentAddress = null;
+    window.PaymentRequest = undefined;
+    window.PaymentAddress = undefined;
 }
 
 module.exports = (window, navigator) => {

--- a/src/interventions/chrome-incognito.js
+++ b/src/interventions/chrome-incognito.js
@@ -32,8 +32,8 @@ limitations under the License.
  * Disables Payment Request.
  */
 function disablePaymentRequest() {
-    window.PaymentRequest = undefined;
-    window.PaymentAddress = undefined;
+    delete window.PaymentRequest;
+    delete window.PaymentAddress;
 }
 
 module.exports = (window, navigator) => {


### PR DESCRIPTION
Turned out some developers detect PaymentRequest feature with following code:
```
if (window.PaymentRequest !== undefined) {
```
Making `window.PaymentRequest = null` will return `true` to this. Hence this pull request makes it `undefined`.

Note this may be even not sufficient. If feature detection is done with:
```
if ('PaymentRequest' in window) {
```
This will still return `true`.

```
delete window.PaymentRequest;
```
might be the best solution.

Let me know what you think > @madmath 
cc: @negimic